### PR TITLE
Updated the weekly releases page to separate v3 and v4 builds. (#5556)

### DIFF
--- a/src/Web/Static/documents/releases/weekly.html.cshtml
+++ b/src/Web/Static/documents/releases/weekly.html.cshtml
@@ -2,16 +2,35 @@
 layout: herosmall
 title: Weekly Releases
 image: /content/red_smoke_4.jpg
-releases?: query documents where sourceRelativePath startswith "documents\releases\v" descending date take 5
+releasesV3?: query documents where sourceRelativePath startswith "documents\releases\v3" descending date take 5
+releasesV4?: query documents where sourceRelativePath startswith "documents\releases\v4" descending date take 5
 
 ---
 
-
 <h2>Weekly Releases</h2>
-<p>The following weekly releases are available. These development releases may be unstable and are therefore not recommended for production use. They are purged irregularly. Please upgrade often (we recommend at least monthly).</p>
-<ul>
-@foreach (var release in @Model.Document.Releases)
-{
- <li><a href="@release.RelativeUrl">@Raw(release.Title)</a> on @release.Date.ToString("dddd, MMMM dd yyyy")</li>
-}
-</ul>
+<p>
+    The following weekly releases are available. These development releases may be unstable and
+    are therefore not recommended for production use. They are purged irregularly. Please upgrade 
+    often (we recommend at least monthly).
+</p>
+
+<div class="col-xs-5">
+    <h3>WiX v3.x</h3>
+    
+    <ul>
+    @foreach (var release in @Model.Document.ReleasesV3)
+    {
+    <li><a href="@release.RelativeUrl">@Raw(release.Title)</a> on @release.Date.ToString("dddd, MMMM dd yyyy")</li>
+    }
+    </ul>
+</div>
+<div class="col-xs-5">
+    <h3>WiX v4.x</h3>
+        
+    <ul>
+    @foreach (var release in @Model.Document.ReleasesV4)
+    {
+    <li><a href="@release.RelativeUrl">@Raw(release.Title)</a> on @release.Date.ToString("dddd, MMMM dd yyyy")</li>
+    }
+    </ul>
+</div>


### PR DESCRIPTION
Converted the bulleted list into two separate Bootstrap columns to show the v3 and v4 builds parallel to one another. This is achieved with two different `releases` models, produced using tinysite (in the doc head, see `releasesv3?` and `releasev4?`), where we had only one `releases` model previously.

I think this will resolve what the customer asked for in [#5556](https://github.com/wixtoolset/issues/issues/5556).

Here's a preview of the page:

![image](https://cloud.githubusercontent.com/assets/12982912/26043471/6e06d09c-390b-11e7-9a7a-0e3950b19ae5.png)
