### PR TITLE
Schema documentation

### DIFF
--- a/src/Web/Static/documents/documentation/manual/v3/howtos/general/extension_usage_introduction.html.md
+++ b/src/Web/Static/documents/documentation/manual/v3/howtos/general/extension_usage_introduction.html.md
@@ -29,9 +29,12 @@ To use a WiX extension when building in Visual Studio with the WiX Visual Studio
 1. Click the Add button to add a reference to the chosen extension DLL.
 1. Browse and add other extension DLLs as needed.
 
-To enable IntelliSense for a WiX extension in the Visual Studio IDE, you need to add an XMLNS declaration to the &lt;Wix&gt; element in your .wxs file. For example, if you want to use the NativeImage functionality in the WixNetFxExtension, the &lt;Wix&gt; element would look like the following:
+To enable IntelliSense for a WiX extension in the Visual Studio IDE, you need to add an `xmlns` declaration to the &lt;Wix&gt;
+element in your .wxs file, as specified in the extension page. For example, if you want to use the NativeImage functionality in the
+Netfx Extension, the &lt;Wix&gt; element would look like the following:
 
     <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
          xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
 
-After adding this, you can add an element named &lt;netfx:NativeImage/&gt; and view IntelliSense for the attributes supported by the NativeImage element.
+After adding this, you can add elements from the Netfx extension, using the `netfx` prefix. For example, to use the NativeImage element,
+add a \<netfx:NativeImage/> element to your code. Now, you can view IntelliSense for the attributes supported by the NativeImage element.

--- a/src/Web/Static/documents/documentation/manual/v3/howtos/general/index.html.md
+++ b/src/Web/Static/documents/documentation/manual/v3/howtos/general/index.html.md
@@ -6,7 +6,10 @@ after: ../updates/
 # How To: General How Tos
 This section includes guides to general topics such as debugging and logging installations.
 
+* [How To: Use WiX Extensions](extension_usage_introduction.html)
+* [How To: Generate a GUID](generate_guids.html)
 * [How To: Get a log of your installation for debugging](get_a_log.html)
 * [How To: Look inside your MSI with Orca](look_inside_msi.html)
-* [How To: Generate a GUID](generate_guids.html)
+* [How To: Optimize build speed](optimizing_builds.html)
+* [How To: Specify source files](specifying_source_files.html)
 

--- a/src/Web/Static/documents/documentation/manual/v3/howtos/general/index.html.md
+++ b/src/Web/Static/documents/documentation/manual/v3/howtos/general/index.html.md
@@ -12,4 +12,3 @@ This section includes guides to general topics such as debugging and logging ins
 * [How To: Look inside your MSI with Orca](look_inside_msi.html)
 * [How To: Optimize build speed](optimizing_builds.html)
 * [How To: Specify source files](specifying_source_files.html)
-

--- a/src/Web/Static/documents/documentation/manual/v3/xsd/index.html.md
+++ b/src/Web/Static/documents/documentation/manual/v3/xsd/index.html.md
@@ -6,6 +6,11 @@ layout: documentation
 
 This section contains schema reference information for WiX and extensions.
 
+In order to use a schema, the DLL file where the schema is defined has to be imported into the installer project, and the schema namespace
+has to be imported as an `xmlns` attribute at the root of the file where it is used. The respective DLL is in the `bin` folder under the WiX
+installation folder. See the specifics for each schema in each schema description.
+
+The exception is the Wix schema, which is automatically referenced and imported, and doesn't need to be manually imported.
 
 * [Wix schema](wix/index.html)
 * [Wixloc schema](wixloc/index.html)

--- a/src/Web/Static/documents/documentation/manual/v3/xsd/util/index.html
+++ b/src/Web/Static/documents/documentation/manual/v3/xsd/util/index.html
@@ -3,13 +3,13 @@ title: Util Schema
 layout: documentation_xsd_extension
 ---
 <p>The elements defined in the Utility Extension.</p>
-<p>In order to use this schema, you should:
+<p>
     <ol>
-        <li>Add Reference in the WiX project to &lt;WiX_install_folder&gt;\bin\WixUtilExtension.dll. If you are using
-        <a href="../../overview/light.html">light.exe</a> directly, use the <code>-ext</code> parameter.</li>
-        <li>Add <code>xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"</code> attribute to the root element of the XML file.</li>
-        <li>Add the <code>util:</code> prefix to each element name as you use it, e.g. <code>util:CloseApplication</code>.</li>
+        <li>Schema is defined in &lt;WiX_install_folder&gt;\bin\WixUtilExtension.dll.</li>
+        <li>Schema namespace is <code>http://schemas.microsoft.com/wix/UtilExtension</code>.</li>
+        <li>Schema prefix is<code>util</code>.</li>
     </ol>
+    See <a href="../../howtos/general/extension_usage_introduction.html">How To: Use WiX Extensions</a> for more details.
 </p>
 <dl>
   <dt>Child Elements</dt>

--- a/src/Web/Static/documents/documentation/manual/v3/xsd/util/index.html
+++ b/src/Web/Static/documents/documentation/manual/v3/xsd/util/index.html
@@ -2,10 +2,15 @@
 title: Util Schema
 layout: documentation_xsd_extension
 ---
-<p>             The source code schema for the Windows Installer XML Toolset Utility Extension.         </p>
+<p>The elements defined in the Utility Extension.</p>
+<p>In order to use this schema, you should:
+    <ol>
+        <li>Add Reference in the WiX project to &lt;WiX_install_folder&gt;\bin\WixUtilExtension.dll</li>
+        <li>Add <code>xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"</code></li>
+        <li>Add the <code>util:</code> prefix to each element name as you use it, e.g. <code>util:CloseApplication</code>.</li>
+    </ol>
+</p>
 <dl>
-  <dt>Target Namespace</dt>
-  <dd>http://schemas.microsoft.com/wix/UtilExtension</dd>
   <dt>Child Elements</dt>
   <dd>
     <ul>

--- a/src/Web/Static/documents/documentation/manual/v3/xsd/util/index.html
+++ b/src/Web/Static/documents/documentation/manual/v3/xsd/util/index.html
@@ -5,8 +5,9 @@ layout: documentation_xsd_extension
 <p>The elements defined in the Utility Extension.</p>
 <p>In order to use this schema, you should:
     <ol>
-        <li>Add Reference in the WiX project to &lt;WiX_install_folder&gt;\bin\WixUtilExtension.dll</li>
-        <li>Add <code>xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"</code></li>
+        <li>Add Reference in the WiX project to &lt;WiX_install_folder&gt;\bin\WixUtilExtension.dll. If you are using
+        <a href="../../overview/light.html">light.exe</a> directly, use the <code>-ext</code> parameter.</li>
+        <li>Add <code>xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"</code> attribute to the root element of the XML file.</li>
         <li>Add the <code>util:</code> prefix to each element name as you use it, e.g. <code>util:CloseApplication</code>.</li>
     </ol>
 </p>


### PR DESCRIPTION
While developing an installer using WiX Toolset, I found the documentation puzzling and far from clear and complete. Often, it seemed like it's using terms only understood by the WiX developers themselves, terms that mean nothing to users.

So I created this branch (and another one), in the hope it will make the documentation clearer. In this pull request the main changes are:
1. Add critical missing information to the Utils schema page. I was using this schema, except fo the default Wix, so that's where I touched. I hope you will make the same change in all schema pages.
2. move repeating text to `howtos/general/extension_usage_introduction.html.md`.
3. Add links to articles in `howtos/general/index.html.md`.