### PR TITLE
Update WIPs 4183 and 6297

### DIFF
--- a/src/Web/Static/documents/bugs.html.md
+++ b/src/Web/Static/documents/bugs.html.md
@@ -11,11 +11,11 @@ Bugs and feature requests for the WiX Toolset are [tracked on GitHub](https://gi
 
 If you think you've encountered a bug in the WiX Toolset or want to request a new feature, first search [the GitHub issue tracker](https://github.com/wixtoolset/issues/issues) to see if someone else has already reported it.
 
-If nobody has, [open an issue on GitHub](https://github.com/wixtoolset/issues/issues/new) and provide the following to help us narrow down, reproduce, and fix the problem.
+If nobody has, [open an issue on GitHub](https://github.com/wixtoolset/issues/issues/new/choose) and provide the following to help us narrow down, reproduce, and fix the problem.
 
 * For a bug, which version of WiX, .NET, and Visual Studio you're using.
 * If the problem happens when installing your packages built with WiX, include the version of Windows the package is running on.
 * A description of the facts of the problem. Be as specific as you can and err on the side of providing too much information, including code, error messages, command lines you used to invoke the build, and so forth.
 * A description of what you expected to happen.
 
-Issues are triaged at weekly online meetings, generally held Fridays at noon Pacific time (UTC-7/UTC-8). Meeting requests are sent to the [wix-devs](http://wixtoolset.org/documentation/mailinglist/#wix-devs) mailing list.
+Issues are triaged at biweekly online meetings, generally held every other Thursday at 9:30 AM Pacific time (UTC-7/UTC-8). Meeting requests are sent to the [wix-devs](https://wixtoolset.org/documentation/mailinglist/#wix-devs) mailing list. Highlights and a video recording of the meeting are posted after the meeting on the [FireGiant blog](https://www.firegiant.com/blog/).


### PR DESCRIPTION
4183:
  Don't remove any attributes from package elements.
  Remove references to Authenticode related attributes that were deleted.
  Add examples.

6297:
  A package is present if installed or cached.
  The BA can force keep registration in `OnUnregisterBegin`, and can no longer cancel from that message.