### PR TITLE
Add Search

### DIFF
--- a/src/Docusaurus/docusaurus.config.js
+++ b/src/Docusaurus/docusaurus.config.js
@@ -141,6 +141,8 @@ const config = {
       'data-domain': "wixtoolset.org"
     }
   ],
+  
+  plugins: [require.resolve("@cmfcmf/docusaurus-search-local")],
 
   webpack: {
     jsLoader: (isServer) => ({

--- a/src/Docusaurus/package-lock.json
+++ b/src/Docusaurus/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wixweb",
       "version": "0.9.0",
       "dependencies": {
+        "@cmfcmf/docusaurus-search-local": "^1.1.0",
         "@docusaurus/core": "^2.3.1",
         "@docusaurus/preset-classic": "^2.3.1",
         "@mdx-js/react": "^1.6.22",
@@ -33,6 +34,47 @@
         "@algolia/autocomplete-shared": "1.7.4"
       }
     },
+    "node_modules/@algolia/autocomplete-js": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.8.3.tgz",
+      "integrity": "sha512-h5v/qp8CwmCUOCaNkUa+vaybnIpIoJGEfwE2Ks/84KAqIHYCBgcylwn92PkIL3gbQCok2sc6JoSIlUo0eAgPsQ==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.8.3",
+        "@algolia/autocomplete-preset-algolia": "1.8.3",
+        "@algolia/autocomplete-shared": "1.8.3",
+        "htm": "^3.1.1",
+        "preact": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.5.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-core": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.8.3.tgz",
+      "integrity": "sha512-DpNL4PZTes+6pg2ysJQzZZBQUvHSYP1q8IkiJA7UoNqFMf0pdq2bSIehuiMTxNegpMjSszaB7G+o5UgxavKhWA==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.8.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.8.3.tgz",
+      "integrity": "sha512-M5B9VZtMtBFS8KSIzv8m0gtwVYtFBBjCvr8boBi+orbQUqzdoj5f70CqhQxUtnNcFGizHUaShUDV571F33/m7g==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.8.3"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.8.3.tgz",
+      "integrity": "sha512-llwPEemKzVhOjL9AsoZPejkaTTAsCB/2HHBQapC8LgQ2E/ipD5M1kTT6oSJskSVO5zI0YbBOCxAigZhgpPJ3eA=="
+    },
     "node_modules/@algolia/autocomplete-preset-algolia": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
@@ -49,6 +91,11 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
       "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+    },
+    "node_modules/@algolia/autocomplete-theme-classic": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.8.3.tgz",
+      "integrity": "sha512-sZt8uyBp5bwPTbqM+2cn/T7/OX8y8neEEtX10wWBgD7gakacn3//VEIdD1/+Yu1TJ2frWoP+SwuEbloe/zsMDg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.14.3",
@@ -1950,6 +1997,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cmfcmf/docusaurus-search-local": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cmfcmf/docusaurus-search-local/-/docusaurus-search-local-1.1.0.tgz",
+      "integrity": "sha512-0IVb/aA0IK8ZlktuxmgXmluXfcSpo6Vdd2nG21y1aOH9nVYnPP231Dn0H8Ng9Qf9ronQQCDWHnuWpYOr9rUrEQ==",
+      "dependencies": {
+        "@algolia/autocomplete-js": "^1.8.2",
+        "@algolia/autocomplete-theme-classic": "^1.8.2",
+        "@algolia/client-search": "^4.12.0",
+        "algoliasearch": "^4.12.0",
+        "cheerio": "^1.0.0-rc.9",
+        "clsx": "^1.1.1",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^2.0.0",
+        "nodejieba": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "nodejieba": {
+          "optional": true
+        }
       }
     },
     "node_modules/@colors/colors": {
@@ -6888,6 +6959,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -7813,6 +7889,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr-languages": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.10.0.tgz",
+      "integrity": "sha512-BBjKKcwrieJlzwwc9M5H/MRXGJ2qyOSDx/NXYiwkuKjiLOOoouh0WsDzeqcLoUWcX31y7i8sb8IgsZKObdUCkw=="
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7834,6 +7915,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "node_modules/markdown-escapes": {
       "version": "1.0.4",
@@ -9241,6 +9327,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.13.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
+      "integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prepend-http": {
@@ -12628,6 +12723,41 @@
         "@algolia/autocomplete-shared": "1.7.4"
       }
     },
+    "@algolia/autocomplete-js": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.8.3.tgz",
+      "integrity": "sha512-h5v/qp8CwmCUOCaNkUa+vaybnIpIoJGEfwE2Ks/84KAqIHYCBgcylwn92PkIL3gbQCok2sc6JoSIlUo0eAgPsQ==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.8.3",
+        "@algolia/autocomplete-preset-algolia": "1.8.3",
+        "@algolia/autocomplete-shared": "1.8.3",
+        "htm": "^3.1.1",
+        "preact": "^10.0.0"
+      },
+      "dependencies": {
+        "@algolia/autocomplete-core": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.8.3.tgz",
+          "integrity": "sha512-DpNL4PZTes+6pg2ysJQzZZBQUvHSYP1q8IkiJA7UoNqFMf0pdq2bSIehuiMTxNegpMjSszaB7G+o5UgxavKhWA==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.8.3"
+          }
+        },
+        "@algolia/autocomplete-preset-algolia": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.8.3.tgz",
+          "integrity": "sha512-M5B9VZtMtBFS8KSIzv8m0gtwVYtFBBjCvr8boBi+orbQUqzdoj5f70CqhQxUtnNcFGizHUaShUDV571F33/m7g==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.8.3"
+          }
+        },
+        "@algolia/autocomplete-shared": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.8.3.tgz",
+          "integrity": "sha512-llwPEemKzVhOjL9AsoZPejkaTTAsCB/2HHBQapC8LgQ2E/ipD5M1kTT6oSJskSVO5zI0YbBOCxAigZhgpPJ3eA=="
+        }
+      }
+    },
     "@algolia/autocomplete-preset-algolia": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.4.tgz",
@@ -12640,6 +12770,11 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.4.tgz",
       "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
+    },
+    "@algolia/autocomplete-theme-classic": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.8.3.tgz",
+      "integrity": "sha512-sZt8uyBp5bwPTbqM+2cn/T7/OX8y8neEEtX10wWBgD7gakacn3//VEIdD1/+Yu1TJ2frWoP+SwuEbloe/zsMDg=="
     },
     "@algolia/cache-browser-local-storage": {
       "version": "4.14.3",
@@ -13966,6 +14101,21 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@cmfcmf/docusaurus-search-local": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cmfcmf/docusaurus-search-local/-/docusaurus-search-local-1.1.0.tgz",
+      "integrity": "sha512-0IVb/aA0IK8ZlktuxmgXmluXfcSpo6Vdd2nG21y1aOH9nVYnPP231Dn0H8Ng9Qf9ronQQCDWHnuWpYOr9rUrEQ==",
+      "requires": {
+        "@algolia/autocomplete-js": "^1.8.2",
+        "@algolia/autocomplete-theme-classic": "^1.8.2",
+        "@algolia/client-search": "^4.12.0",
+        "algoliasearch": "^4.12.0",
+        "cheerio": "^1.0.0-rc.9",
+        "clsx": "^1.1.1",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1"
       }
     },
     "@colors/colors": {
@@ -17598,6 +17748,11 @@
         }
       }
     },
+    "htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+    },
     "html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -18240,6 +18395,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr-languages": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.10.0.tgz",
+      "integrity": "sha512-BBjKKcwrieJlzwwc9M5H/MRXGJ2qyOSDx/NXYiwkuKjiLOOoouh0WsDzeqcLoUWcX31y7i8sb8IgsZKObdUCkw=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -18254,6 +18414,11 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
+    },
+    "mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "markdown-escapes": {
       "version": "1.0.4",
@@ -19181,6 +19346,11 @@
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
       "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
       "requires": {}
+    },
+    "preact": {
+      "version": "10.13.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
+      "integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw=="
     },
     "prepend-http": {
       "version": "2.0.0",

--- a/src/Docusaurus/package.json
+++ b/src/Docusaurus/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
+    "@cmfcmf/docusaurus-search-local": "^1.1.0",
     "@docusaurus/core": "^2.3.1",
     "@docusaurus/preset-classic": "^2.3.1",
     "@mdx-js/react": "^1.6.22",

--- a/src/Docusaurus/src/css/custom.css
+++ b/src/Docusaurus/src/css/custom.css
@@ -16,8 +16,8 @@
   --ifm-color-primary-lightest: #a91e1e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-  --aa-primary-color-rgb: #821717 !important;
-  --aa-muted-color-rgb: #751515 !important;
+  --aa-primary-color-rgb: 130, 23, 23 !important;
+  --aa-muted-color-rgb: 117, 21, 21 !important;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -31,8 +31,12 @@
   --ifm-color-primary-lighter: #ffd7d7;
   --ifm-color-primary-lightest: #ffffff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
-  --aa-primary-color-rgb: #fe9a9a !important;
-  --aa-muted-color-rgb: #fe7272 !important;
+  --aa-primary-color-rgb: 254, 154, 154 !important;
+  --aa-muted-color-rgb: 254, 114, 114 !important;
+  --aa-background-color-rgb: 17, 17, 19 !important;
+  --aa-input-background-color-rgb: 27, 27, 29 !important;
+  --aa-panel-border-color-rgb: 254, 114, 114 !important;
+  --aa-input-border-color-rgb: 254, 114, 114 !important;
 }
 
 .footer_label {

--- a/src/Docusaurus/src/css/custom.css
+++ b/src/Docusaurus/src/css/custom.css
@@ -16,6 +16,8 @@
   --ifm-color-primary-lightest: #a91e1e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --aa-primary-color-rgb: #821717 !important;
+  --aa-muted-color-rgb: #751515 !important;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -29,6 +31,8 @@
   --ifm-color-primary-lighter: #ffd7d7;
   --ifm-color-primary-lightest: #ffffff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --aa-primary-color-rgb: #fe9a9a !important;
+  --aa-muted-color-rgb: #fe7272 !important;
 }
 
 .footer_label {


### PR DESCRIPTION
Added a Docusaurus plugin for a search utility that doesn't require an external service. Adding the package also bumped a number of related package versions. Note: Having trouble matching the search CSS to the site CSS.

NOTE: I was having trouble overriding the default search CSS for the background and input colors. I can spend more time on that if you want to proceed with this change overall. It should have been easy by adding a few more entries to the css file for `--aa-input-background-color-rgb` and `--aa-background-color-rgb` but it wasn't working.

Fixes wixtoolset/issues#7363