### PR TITLE
Update signing.md for detach example

### DIFF
--- a/src/Docusaurus/docs/tools/signing.md
+++ b/src/Docusaurus/docs/tools/signing.md
@@ -113,7 +113,7 @@ To sign the whole bundle, create a `SignBundle` target in your .wixproj to call 
 To extract the Burn engine from the bundle:
 
 ```sh
-wix burn detach -engine path\to\extracted\burnengine.exe
+wix burn detach path\to\bundle.exe -engine path\to\extracted\burnengine.exe
 ```
 
 Then sign path\to\extracted\burnengine.exe.


### PR DESCRIPTION
The example omits that the user needs to provide the path to the bundle.exe before -engine, something the command line reference does provide. This brings parity between the command line reference and this example. 

I have read the CLA Document and I hereby sign the CLA Document