### PR TITLE
Fix markdown syntax in wixui_dialog_library.md

### DIFF
--- a/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_dialog_library.md
+++ b/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_dialog_library.md
@@ -19,30 +19,23 @@ The built-in WixUI dialog sets are also customizable, from the bitmaps shown in 
 
 Assuming you have an existing installer that is functional but is just lacking a user interface, here are the steps you need to follow to include a built-in WixUI dialog set:
 
-<ol>
-  <li>Add a UIRef element to your setup authoring that has an Id that matches the name of one of the dialog sets described above. For example:
-    ```
-&lt;Product ...&gt;
-&lt;UIRef Id="WixUI_InstallDir" /&gt;
-&lt;/Product&gt;
-```
-  </li>
+1. Add a UIRef element to your setup authoring that has an Id that matches the name of one of the dialog sets described above. For example:
 
-  <li>Pass the -ext and -cultures switches to [light.exe](../overview/light.md) to reference the WixUIExtension. For example:
-    ```
+```
+<Product ...>
+<UIRef Id="WixUI_InstallDir" />
+</Product>
+```
+
+2. Pass the -ext and -cultures switches to [light.exe](../overview/light.md) to reference the WixUIExtension. For example:
+
+```
 light -ext WixUIExtension -cultures:en-us Product.wixobj -out Product.msi
 ```
 
-    <p>Note - If you are using WiX in Visual Studio you can add the WixUIExtension using the Add Reference dialog and the necessary command lines will automatically be added when linking your .msi. To do this, use the following steps:</p>
+Note - If you are using WiX in Visual Studio you can add the WixUIExtension using the Add Reference dialog and the necessary command lines will automatically be added when linking your .msi. To do this, use the following steps:
 
-    <ol>
-      <li>Open your WiX project in Visual Studio</li>
-
-      <li>Right click on your project in Solution Explorer and select Add Reference...</li>
-
-      <li>Select the <strong>WixUIExtension.dll</strong> assembly from the list and click Add</li>
-
-      <li>Close the Add Reference dialog</li>
-    </ol>
-  </li>
-</ol>
+1. Open your WiX project in Visual Studio
+2. Right click on your project in Solution Explorer and select Add Reference...
+3. Select the **WixUIExtension.dll** assembly from the list and click Add
+4. Close the Add Reference dialog


### PR DESCRIPTION
Markdown was mixed with HTML and the page was not rendering correctly.