### PR TITLE
Fix code snippets in markdown

### DIFF
--- a/src/Docusaurus/versioned_docs/version-v3/bundle/authoring_bundle_package_manifest.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/authoring_bundle_package_manifest.md
@@ -16,41 +16,41 @@ The WiX schema supports the following chained package types:
 
 Here is an example of authoring an ExePackage in a sharable fragment:
 
-```
-    <?xml version="1.0"?>
-    <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-      <Fragment>
-        <PackageGroup Id="MyPackage">
-            <ExePackage 
-              SourceFile="[sources]\packages\shared\MyPackage.exe"
-              DetectCondition="ExeDetectedVariable"
-              DownloadUrl="http://example.com/?mypackage.exe"
-              InstallCommand="/q /ACTION=Install"
-              RepairCommand="/q ACTION=Repair /hideconsole"
-              UninstallCommand="/q ACTION=Uninstall /hideconsole" />
-        </PackageGroup>
-      </Fragment>
-    </Wix>
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <PackageGroup Id="MyPackage">
+        <ExePackage 
+          SourceFile="[sources]\packages\shared\MyPackage.exe"
+          DetectCondition="ExeDetectedVariable"
+          DownloadUrl="http://example.com/?mypackage.exe"
+          InstallCommand="/q /ACTION=Install"
+          RepairCommand="/q ACTION=Repair /hideconsole"
+          UninstallCommand="/q ACTION=Uninstall /hideconsole" />
+    </PackageGroup>
+  </Fragment>
+</Wix>
 ```
 
 Now you can add an install condition to the package so that it only installs on x86 Windows XP and above. There are [built-in variables](bundle_built_in_variables.md) that can be used to construct these condition statements. The highlighted section shows how to leverage the built-in variables to create that condition:
 
-```
-    &lt;?xml version=&quot;1.0&quot;?&gt;
-    &lt;Wix xmlns=&quot;http://schemas.microsoft.com/wix/2006/wi&quot;&gt;
-      &lt;Fragment&gt;
-        &lt;PackageGroup Id=&quot;MyPackage&quot;&gt;
-            &lt;ExePackage 
-              SourceFile=&quot;[sources]\packages\shared\MyPackage.exe&quot;
-              DetectCondition=&quot;ExeDetectedVariable&quot;
-              DownloadUrl=&quot;http://example.com/?mypackage.exe&quot;
-              InstallCommand=&quot;/q /ACTION=Install&quot;
-              RepairCommand=&quot;/q ACTION=Repair /hideconsole&quot;
-              UninstallCommand=&quot;/q ACTION=Uninstall /hideconsole&quot; 
-              <strong class="highlight">InstallCondition=&quot;NOT VersionNT64 AND VersionNT &gt;= v5.1&quot;</strong> /&gt;
-        &lt;/PackageGroup&gt;
-      &lt;/Fragment&gt;
-    &lt;/Wix&gt;
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <PackageGroup Id="MyPackage">
+        <ExePackage 
+          SourceFile="[sources]\packages\shared\MyPackage.exe"
+          DetectCondition="ExeDetectedVariable"
+          DownloadUrl="http://example.com/?mypackage.exe"
+          InstallCommand="/q /ACTION=Install"
+          RepairCommand="/q ACTION=Repair /hideconsole"
+          UninstallCommand="/q ACTION=Uninstall /hideconsole" 
+          <strong class="highlight">InstallCondition="NOT VersionNT64 AND VersionNT >= v5.1"</strong> />
+    </PackageGroup>
+  </Fragment>
+</Wix>
 ```
 
 The VersionNT property takes up to a four-part version number ([Major].[Minor].[Build].[Revision]). For a list of major and minor versions of the Windows operating system, see <a href="http://msdn.microsoft.com/library/ms724832.aspx" target="_blank">Operating System Version</a>.

--- a/src/Docusaurus/versioned_docs/version-v3/bundle/bundle_define_searches.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/bundle_define_searches.md
@@ -14,55 +14,55 @@ Searches are used to detect if the target machine meets certain conditions. The 
 * [ProductSearch](../xsd/util/productsearch.md)
 
 A search can be dependent on the result of another search. Keep in mind that all searches are in the WiXUtilExtension. So remember to add the WiXUtilExtension namespace in the authoring. Here is an example:
-
-    <?xml version="1.0"?>
-    <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
-         xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-      <Fragment>
-        <util:RegistrySearch Id="Path"
-            Variable="UniqueId"
-            Root="HKLM"
-            Key="Software\MyCompany\MyProduct\Unique Id\Product"
-            Result="Value" />
-        <util:RegistrySearch 
-            Variable="patchLevel"
-            Root="HKLM"
-            Key="Software\MyCompany\MyProduct\[UniqueId]\Setup\PatchLevel"
-            Result="Exists" 
-            After="Path" />
-      </Fragment>
-    </Wix>
-
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <util:RegistrySearch Id="Path"
+        Variable="UniqueId"
+        Root="HKLM"
+        Key="Software\MyCompany\MyProduct\Unique Id\Product"
+        Result="Value" />
+    <util:RegistrySearch 
+        Variable="patchLevel"
+        Root="HKLM"
+        Key="Software\MyCompany\MyProduct\[UniqueId]\Setup\PatchLevel"
+        Result="Exists" 
+        After="Path" />
+  </Fragment>
+</Wix>
+```
 After the searches are defined and stored into variables, the variables can then be used in install conditions. For example, you can use the result of the registry searches in the install condition of your package by adding both the searches and the install conditions. Here&apos;s an example of a complete fragment that contains a package definition with conditions and searches:
 
 ```
-   &lt;?xml version=&quot;1.0&quot;?&gt;
-    &lt;Wix xmlns=&quot;http://schemas.microsoft.com/wix/2006/wi&quot;
-         xmlns:util=&quot;http://schemas.microsoft.com/wix/UtilExtension&quot;&gt;
-      &lt;Fragment&gt;
-        &lt;util:RegistrySearch Id=&quot;Path&quot;
-            Variable=&quot;UniqueId&quot;
-            Root=&quot;HKLM&quot;
-            Key=&quot;Software\MyCompany\MyProduct\Unique Id\Product&quot;
-            Result=&quot;Value&quot; /&gt;
-        &lt;util:RegistrySearch 
-            Variable=&quot;patchLevel&quot;
-            Root=&quot;HKLM&quot;
-            Key=&quot;Software\MyCompany\MyProduct\[UniqueId]\Setup\PatchLevel&quot;
-            Result=&quot;Exists&quot; 
-            After=&quot;Path&quot; /&gt;
+<?xml version="1.0"?>
+ <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Fragment>
+    <util:RegistrySearch Id="Path"
+        Variable="UniqueId"
+        Root="HKLM"
+        Key="Software\MyCompany\MyProduct\Unique Id\Product"
+        Result="Value" />
+    <util:RegistrySearch 
+        Variable="patchLevel"
+        Root="HKLM"
+        Key="Software\MyCompany\MyProduct\[UniqueId]\Setup\PatchLevel"
+        Result="Exists" 
+        After="Path" />
 
-        &lt;PackageGroup Id=&quot;MyPackage&quot;&gt;
-          &lt;ExePackage 
-            SourceFile=&quot;[sources]\packages\shared\MyPackage.exe&quot;
-            DownloadURL=&quot;http://mywebdomain.com/?mypackage.exe&quot;
-            InstallCommand=&quot;/q /ACTION=Install&quot;
-            RepairCommand=&quot;/q ACTION=Repair /hideconsole&quot;
-            UninstallCommand=&quot;/q ACTION=Uninstall /hideconsole&quot;
-            InstallCondition=&quot;x86 = 1 AND OSVersion &gt;= v5.0.5121.0 <strong class="highlight">AND patchLevel = 0</strong>&quot; /&gt;
-        &lt;/PackageGroup&gt;
-      &lt;/Fragment&gt;
-    &lt;/Wix&gt;
+    <PackageGroup Id="MyPackage">
+      <ExePackage 
+        SourceFile="[sources]\packages\shared\MyPackage.exe"
+        DownloadURL="http://mywebdomain.com/?mypackage.exe"
+        InstallCommand="/q /ACTION=Install"
+        RepairCommand="/q ACTION=Repair /hideconsole"
+        UninstallCommand="/q ACTION=Uninstall /hideconsole"
+        InstallCondition="x86 = 1 AND OSVersion >= v5.0.5121.0 <strong class="highlight">AND patchLevel = 0</strong>" />
+    </PackageGroup>
+  </Fragment>
+</Wix>
 ```
 
 Now you have a fully-defined fragment that can be shared to be consumed by other Burn packages. To see how to chain this package into a Burn package, see [Chain Packages into a Bundle](bundle_author_chain.md).

--- a/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_branding.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_branding.md
@@ -5,44 +5,44 @@ after: wixstdba_license
 ---
 # Changing the WiX Standard Bootstrapper Application Branding
 
-The WiX Standard Bootstrapper Application displays a generic logo in the bottom left corner of the user interface. It is possible to change the image displayed using the WixStandardBootstrapperApplication element provided by WixBalExtension. The following example uses a &quot;customlogo.png&quot; file found in the &quot;path\to&quot; folder relative to the linker bind paths.
+The WiX Standard Bootstrapper Application displays a generic logo in the bottom left corner of the user interface. It is possible to change the image displayed using the WixStandardBootstrapperApplication element provided by WixBalExtension. The following example uses a "customlogo.png" file found in the "path\to" folder relative to the linker bind paths.
 
-```
-    &lt;?xml version=&quot;1.0&quot;?&gt;
-    &lt;Wix xmlns=&quot;http://schemas.microsoft.com/wix/2006/wi&quot;
-         xmlns:bal=&quot;http://schemas.microsoft.com/wix/BalExtension&quot;&gt;
-      &lt;Bundle&gt;
-        &lt;BootstrapperApplicationRef Id=&quot;WixStandardBootstrapperApplication.RtfLicense&quot;&gt;
-          &lt;bal:WixStandardBootstrapperApplication
-            LicenseFile=&quot;path\to\license.rtf&quot;
-            <strong class="highlight">LogoFile=&quot;path\to\customlogo.png&quot;</strong>
-            /&gt;
-        &lt;/BootstrapperApplicationRef&gt;
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <Bundle>
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
+      <bal:WixStandardBootstrapperApplication
+        LicenseFile="path\to\license.rtf"
+        <strong class="highlight">LogoFile="path\to\customlogo.png"</strong>
+        />
+    </BootstrapperApplicationRef>
 
-        &lt;Chain&gt;
-          ...
-        &lt;/Chain&gt;
-      &lt;/Bundle&gt;
-    &lt;/Wix&gt;
+    <Chain>
+      ...
+    </Chain>
+  </Bundle>
+</Wix>
 ```
 
 For the HyperlinkSidebarLicense UI, there are two logos and they can be configured as follows:
 
-```
-    &lt;?xml version=&quot;1.0&quot;?&gt;
-    &lt;Wix xmlns=&quot;http://schemas.microsoft.com/wix/2006/wi&quot;
-         xmlns:bal=&quot;http://schemas.microsoft.com/wix/BalExtension&quot;&gt;
-      &lt;Bundle&gt;
-        &lt;BootstrapperApplicationRef Id=&quot;WixStandardBootstrapperApplication.HyperlinkSidebarLicense&quot;&gt;
-          &lt;bal:WixStandardBootstrapperApplication
-            LicenseUrl=&quot;License.htm&quot;
-            <strong class="highlight">LogoFile=&quot;path\to\customlogo.png&quot; LogoSideFile=&quot;path\to\customsidelogo.png&quot;</strong>
-            /&gt;
-        &lt;/BootstrapperApplicationRef&gt;
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <Bundle>
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkSidebarLicense">
+      <bal:WixStandardBootstrapperApplication
+        LicenseUrl="License.htm"
+        <strong class="highlight">LogoFile="path\to\customlogo.png" LogoSideFile="path\to\customsidelogo.png"</strong>
+        />
+    </BootstrapperApplicationRef>
 
-        &lt;Chain&gt;
-          ...
-        &lt;/Chain&gt;
-      &lt;/Bundle&gt;
-    &lt;/Wix&gt;
+    <Chain>
+      ...
+    </Chain>
+  </Bundle>
+</Wix>
 ```

--- a/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_license.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_license.md
@@ -7,46 +7,46 @@ layout: documentation
 
 The WiX Standard Bootstrapper Application (WixStdBA) supports displaying a license in RTF format and/or linking to a license file that either exists locally or on the web. The license file is specified in the <bal:WixStandardBootstrapperApplication> element using the LicenseFile or LicenseUrl attribute, depending on which WixStdBA theme is used.
 
-When using a WixStdBA theme that displays the RTF license, it is highly recommended that the license is overridden because the default uses &quot;Lorem ipsum&quot; placeholder text. The following example uses a license.rtf file found in the &quot;path\to&quot; folder relative to the linker bind paths.
+When using a WixStdBA theme that displays the RTF license, it is highly recommended that the license is overridden because the default uses "Lorem ipsum" placeholder text. The following example uses a license.rtf file found in the "path\to" folder relative to the linker bind paths.
 
-```
-    &lt;?xml version=&quot;1.0&quot;?&gt;
-    &lt;Wix xmlns=&quot;http://schemas.microsoft.com/wix/2006/wi&quot; xmlns:bal=&quot;http://schemas.microsoft.com/wix/BalExtension&quot;&gt;
-      &lt;Bundle&gt;
-        &lt;BootstrapperApplicationRef Id=&quot;WixStandardBootstrapperApplication.RtfLicense&quot;&gt;
-          &lt;bal:WixStandardBootstrapperApplication
-            <strong class="highlight">LicenseFile=&quot;path\to\license.rtf&quot;</strong>
-            LogoFile=&quot;path\to\customlogo.png&quot;
-            /&gt;
-        &lt;/BootstrapperApplicationRef&gt;
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <Bundle>
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
+      <bal:WixStandardBootstrapperApplication
+        <strong class="highlight">LicenseFile="path\to\license.rtf"</strong>
+        LogoFile="path\to\customlogo.png"
+        />
+    </BootstrapperApplicationRef>
 
-        &lt;Chain&gt;
-          ...
-        &lt;/Chain&gt;
-      &lt;/Bundle&gt;
-    &lt;/Wix&gt;
+    <Chain>
+      ...
+    </Chain>
+  </Bundle>
+</Wix>
 ```
 
 The following example links to a license page on the internet.
 
-```
-    &lt;?xml version=&quot;1.0&quot;?&gt;
-    &lt;Wix xmlns=&quot;http://schemas.microsoft.com/wix/2006/wi&quot; xmlns:bal=&quot;http://schemas.microsoft.com/wix/BalExtension&quot;&gt;
-      &lt;Bundle&gt;
-        &lt;BootstrapperApplicationRef Id=&quot;WixStandardBootstrapperApplication.HyperlinkLicense&quot;&gt;
-          &lt;bal:WixStandardBootstrapperApplication
-            <strong class="highlight">LicenseUrl=&quot;http://example.com/license.html&quot;</strong>
-            LogoFile=&quot;path\to\customlogo.png&quot;
-            /&gt;
-        &lt;/BootstrapperApplicationRef&gt;
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <Bundle>
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
+      <bal:WixStandardBootstrapperApplication
+        <strong class="highlight">LicenseUrl="http://example.com/license.html"</strong>
+        LogoFile="path\to\customlogo.png"
+        />
+    </BootstrapperApplicationRef>
 
-        &lt;Chain&gt;
-          ...
-        &lt;/Chain&gt;
-      &lt;/Bundle&gt;
-    &lt;/Wix&gt;
+    <Chain>
+      ...
+    </Chain>
+  </Bundle>
+</Wix>
 ```
 
-When using a WixStdBA theme that displays the license as a hyperlink, the license is optional. Provide an empty string for WixStandardBootstrapperApplication/@LicenseUrl---the hyperlink and accept license checkbox are not displayed, providing an &quot;unlicensed&quot; installation experience. 
+When using a WixStdBA theme that displays the license as a hyperlink, the license is optional. Provide an empty string for WixStandardBootstrapperApplication/@LicenseUrl---the hyperlink and accept license checkbox are not displayed, providing an "unlicensed" installation experience.
 
 If you get an error indicating `The Windows Installer XML variable !(wix.WixStdbaLicenseUrl) is unknown`, provide a value for WixStandardBootstrapperApplication/@LicenseUrl, even if it's an empty string.

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/perfmon.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/perfmon.md
@@ -13,66 +13,74 @@ The PerfCounter element (part of WiXUtilExtension) allows you to register your p
 * The RegisterPerfmon custom action - You can link with the WiXUtilExtension.dll to ensure that the custom actions are included in your final MSI. See [Using Standard Custom Actions](using_standard_customactions.md). The custom action calls (Un)LoadPerfCounterTextStrings to register your counters with Windows&#65533; Perfmon API. To invoke the custom action, you create a PerfCounter element nested within the File element for the Perfmon.INI file. The PerfCounter element contains a single attribute: Name. The Name attribute should match the name in the Registry and in the .INI file. See below for sample WIX usage of the &lt;PerfCounter&gt; element.
 
 ## Sample WIX source fragment and PerfCounter.ini
-    <?xml version="1.0"?>
-    <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <Fragment>
-      <DirectoryRef Id="BinDir">
-        <Component Id="SharedNative" DiskId="1">
-    
-          <Registry Id="Shared_r1" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Open" Value="OpenPerformanceData" Type="string" />
-          <Registry Id="Shared_r2" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Collect" Value="CollectPerformanceData" Type="string" />
-          <Registry Id="Shared_r3" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Close" Value="ClosePerformanceData" Type="string" />
-          <Registry Id="Shared_r4" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Library" Value="[!PERFDLL.DLL]" Type="string" />
-    
-         <File Id="PERFDLL.DLL" Name="MyPerfDll.dll" Source="x86\debug\0\myperfdll.dll" />
-    
-         <File Id="PERFCOUNTERS.H" Name="PerfCounters.h" Source="x86\debug\0\perfcounters.h" />
-         <File Id="PERFCOUNTERS.INI" Name="PerfCounters.ini" Source="x86\debug\0\perfcounters.ini" >
-            <PerfCounter Name="MyApplication" />
-         </File>
-    
-        </Component>
-      </DirectoryRef>
-    </Fragment>
-    </Wix>
 
-&nbsp;  
+```xml
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Fragment>
+  <DirectoryRef Id="BinDir">
+    <Component Id="SharedNative" DiskId="1">
 
-    Sample PerfCounters.ini:
-    [info]
-    drivername=MyApplication
-    symbolfile=PerfCounters.h
-    
-    [languages] 
-    009=English
-    004=Chinese
-    
-    [objects]
-    PERF_OBJECT_1_009_NAME=Performance object name
-    PERF_OBJECT_1_004_NAME=Performance object name in Chinese
-    
-    [text]
-    OBJECT_1_009_NAME=Name of the device
-    OBJECT_1_009_HELP=Displays performance statistics of the device
-    OBJECT_1_004_NAME=Name of the device in Chinese
-    OBJECT_1_004_HELP=Displays performance statistics of the device in Chinese
-    
-    DEVICE_COUNTER_1_009_NAME=Name of first counter
-    DEVICE_COUNTER_1_009_HELP=Displays the current value of the first counter
-    DEVICE_COUNTER_1_004_NAME=Name of the first counter in Chinese
-    DEVICE_COUNTER_1_004_HELP=Displays the value of the first counter in Chinese
-    
-    DEVICE_COUNTER_2_009_NAME=Name of the second counter
-    DEVICE_COUNTER_2_009_HELP=Displays the current rate of the second counter
-    DEVICE_COUNTER_2_004_NAME=Name of the second counter in Chinese
-    DEVICE_COUNTER_2_004_HELP=Displays the rate of the second counter in Chinese
-    
-    PERF_OBJECT_1_009_NAME=Name of the third counter
-    PERF_OBJECT_1_009_HELP=Displays the current rate of the third counter
-    PERF_OBJECT_1_004_NAME=Name of the third counter in Chinese
-    PERF_OBJECT_1_004_HELP=Displays the rate of the third counter in Chinese
-    Sample PerfCounters.h:
-    #define OBJECT_1    0
-    #define DEVICE_COUNTER_1    2
-    #define DEVICE_COUNTER_2    4
-    #define PERF_OBJECT_1    8
+      <Registry Id="Shared_r1" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Open" Value="OpenPerformanceData" Type="string" />
+      <Registry Id="Shared_r2" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Collect" Value="CollectPerformanceData" Type="string" />
+      <Registry Id="Shared_r3" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Close" Value="ClosePerformanceData" Type="string" />
+      <Registry Id="Shared_r4" Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\MyApplication\Performance" Name="Library" Value="[!PERFDLL.DLL]" Type="string" />
+
+     <File Id="PERFDLL.DLL" Name="MyPerfDll.dll" Source="x86\debug\0\myperfdll.dll" />
+
+     <File Id="PERFCOUNTERS.H" Name="PerfCounters.h" Source="x86\debug\0\perfcounters.h" />
+     <File Id="PERFCOUNTERS.INI" Name="PerfCounters.ini" Source="x86\debug\0\perfcounters.ini" >
+        <PerfCounter Name="MyApplication" />
+     </File>
+
+    </Component>
+  </DirectoryRef>
+</Fragment>
+</Wix>
+```
+
+Sample PerfCounters.ini:
+
+```ini
+[info]
+drivername=MyApplication
+symbolfile=PerfCounters.h
+
+[languages] 
+009=English
+004=Chinese
+
+[objects]
+PERF_OBJECT_1_009_NAME=Performance object name
+PERF_OBJECT_1_004_NAME=Performance object name in Chinese
+
+[text]
+OBJECT_1_009_NAME=Name of the device
+OBJECT_1_009_HELP=Displays performance statistics of the device
+OBJECT_1_004_NAME=Name of the device in Chinese
+OBJECT_1_004_HELP=Displays performance statistics of the device in Chinese
+
+DEVICE_COUNTER_1_009_NAME=Name of first counter
+DEVICE_COUNTER_1_009_HELP=Displays the current value of the first counter
+DEVICE_COUNTER_1_004_NAME=Name of the first counter in Chinese
+DEVICE_COUNTER_1_004_HELP=Displays the value of the first counter in Chinese
+
+DEVICE_COUNTER_2_009_NAME=Name of the second counter
+DEVICE_COUNTER_2_009_HELP=Displays the current rate of the second counter
+DEVICE_COUNTER_2_004_NAME=Name of the second counter in Chinese
+DEVICE_COUNTER_2_004_HELP=Displays the rate of the second counter in Chinese
+
+PERF_OBJECT_1_009_NAME=Name of the third counter
+PERF_OBJECT_1_009_HELP=Displays the current rate of the third counter
+PERF_OBJECT_1_004_NAME=Name of the third counter in Chinese
+PERF_OBJECT_1_004_HELP=Displays the rate of the third counter in Chinese
+```
+
+Sample PerfCounters.h:
+
+```c
+#define OBJECT_1    0
+#define DEVICE_COUNTER_1    2
+#define DEVICE_COUNTER_2    4
+#define PERF_OBJECT_1    8
+```

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/qtexec.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/qtexec.md
@@ -24,6 +24,7 @@ The `WixSilentExec` actions introduced in WiX v3.10 already support the new nami
 
 When the QtExec action is run as an immediate custom action, it will try to execute the command stored in the WixQuietExecCmdLine property. The following is an example of authoring an immediate QtExec custom action:
 
+```xml
     <Property Id="WixQuietExecCmdLine" Value="command line to run"/>
     <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
     .
@@ -32,8 +33,9 @@ When the QtExec action is run as an immediate custom action, it will try to exec
     <InstallExecuteSequence>
       <Custom Action="QtExecExample" After="TheActionYouWantItAfter"/>
     </InstallExecuteSequence>
+```
 
-This will result in running the command line in the immediate sequence. If the exit code of the command line in this example indicates an error (meaning that the return code is not equal to 0) then the setup will fail because the Return value is set to &ldquo;check.&quot; Changing the Return value to &quot;ignore&quot; will cause the setup to log the failure but skip it and continue instead of failing the entire setup.
+This will result in running the command line in the immediate sequence. If the exit code of the command line in this example indicates an error (meaning that the return code is not equal to 0) then the setup will fail because the Return value is set to "check". Changing the Return value to "ignore" will cause the setup to log the failure but skip it and continue instead of failing the entire setup.
 
 If you want to run more than one command line in the immediate sequence then you will need to schedule multiple QtExec custom actions and set the WixQuietExecCmdLine property to a new value by scheduling a property-setting custom action immediately before each instance of the QtExec custom action.
 
@@ -41,6 +43,7 @@ If you want to run more than one command line in the immediate sequence then you
 
 If you need to run a program without logging any of the input parameters or output of the executable __for example, for security or privacy reasons,__ you want WixSilentExec:
 
+```xml
     <Property Id="WixSilentExecCmdLine" Value="command line to run" Hidden="yes"/>
     <CustomAction Id="SilentExecExample" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="check"/>
     .
@@ -49,6 +52,7 @@ If you need to run a program without logging any of the input parameters or outp
     <InstallExecuteSequence>
       <Custom Action="SilentExecExample" After="TheActionYouWantItAfter"/>
     </InstallExecuteSequence>
+```
 
 The *only* difference in behavior between WixQuietExec and WixSilentExec is that WixSilentExec never logs the input or output of the command line. Take special note to mark the input property and other properties as hidden if you do not want them logged automatically by MSI.
 
@@ -56,6 +60,7 @@ The *only* difference in behavior between WixQuietExec and WixSilentExec is that
 
 When the WixQuietExec (or WixSilentExec) action is run as a deferred custom action, it will try to execute the command line stored in the value of the custom action data. For deferred QtExec custom actions, the custom action data is a property that has the same Id value as the custom action Id. The following is an example of authoring a deferred QtExec custom action:
 
+```xml
     <Property Id="QtExecDeferredExample" Value="command line to run"/>
     <CustomAction Id="QtExecDeferredExample" BinaryKey="WixCA" DllEntry="WixQuietExec"
                 Execute="deferred" Return="check" Impersonate="no"/>
@@ -65,10 +70,12 @@ When the WixQuietExec (or WixSilentExec) action is run as a deferred custom acti
     <InstallExecuteSequence>
       <Custom Action="QtExecDeferredExample" After="TheActionYouWantItAfter"/>
     </InstallExecuteSequence>
+```
 
 If you need to set a command line that uses other Windows Installer properties, you must schedule an immediate custom action to set the command line property value and schedule a deferred custom action to run QtExec. The property Id used in the SetProperty custom action must match the Id value used in the deferred custom action. A common use of this pattern for QtExec custom actions is to run an executable that will be installed as a part of the setup. The following is an example of authoring a deferred QtExec custom action that relies on another property value:
 
-    <SetProperty Id="QtExecDeferredExampleWithProperty" Value="&quot;[#MyExecutable.exe]&quot;"
+```xml
+    <SetProperty Id="QtExecDeferredExampleWithProperty" Value=""[#MyExecutable.exe]""
                 Sequence="execute" Before="QtExecDeferredExampleWithProperty" />
     <CustomAction Id="QtExecDeferredExampleWithProperty" BinaryKey="WixCA" DllEntry="WixQuietExec"
                 Execute="deferred" Return="check" Impersonate="no"/>
@@ -78,17 +85,19 @@ If you need to set a command line that uses other Windows Installer properties, 
     <InstallExecuteSequence>
       <Custom Action="QtExecDeferredExampleWithProperty" After="TheActionYouWantItAfter"/>
     </InstallExecuteSequence>
+```
 
 ## Running 64-bit executables
 
-If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 64-bit QtExec (or WixSilentExec) change the CustomAction element&apos;s DllEntry attribute to &quot;WixQuietExec64&quot; (or &quot;WixSilentExec64&quot;) and for immediate execution use the &quot;WixQuietExec64CmdLine&quot; (or &quot;WixSilentExec64CmdLine&quot;) property. The following example combines the examples above the 64-bit aware QtExec for both. Notice that the CustomAction element&apos;s Id attributes do not need to change:
+If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 64-bit QtExec (or WixSilentExec) change the CustomAction element&apos;s DllEntry attribute to "WixQuietExec64" (or "WixSilentExec64") and for immediate execution use the "WixQuietExec64CmdLine" (or "WixSilentExec64CmdLine") property. The following example combines the examples above the 64-bit aware QtExec for both. Notice that the CustomAction element&apos;s Id attributes do not need to change:
 
+```xml
     <Property Id="WixQuietExec64CmdLine" Value="64-bit command line to run"/>
     <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check"/>
     .
     .
     .
-    <SetProperty Id="QtExecDeferredExampleWithProperty" Value="&quot;[#MyExecutable.exe]&quot;" 
+    <SetProperty Id="QtExecDeferredExampleWithProperty" Value=""[#MyExecutable.exe]"" 
                 Before="QtExecDeferredExampleWithProperty" Sequence="execute" />
     <CustomAction Id="QtExecDeferredExampleWithProperty" BinaryKey="WixCA" DllEntry="WixQuietExec64"
                 Execute="deferred" Return="check" Impersonate="no"/>
@@ -99,6 +108,7 @@ If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 
       <Custom Action="QtExecExample" After="TheImmediateActionYouWantItAfter"/>
       <Custom Action="QtExecDeferredExampleWithProperty" After="TheDeferredActionYouWantItAfter"/>
     </InstallExecuteSequence>
+```
 
 ## Building an MSI that uses QtExec
 

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/using_standard_customactions.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/using_standard_customactions.md
@@ -9,29 +9,31 @@ Custom actions add the ability to install and configure many new types of resour
 
 ## Example
 
-First, let&apos;s try an example that creates a user account when the MSI is installed. This functionality is defined in WixUtilExtension.dll and exposed to the user as the &lt;User&gt; element.
+First, let's try an example that creates a user account when the MSI is installed. This functionality is defined in WixUtilExtension.dll and exposed to the user as the &lt;User&gt; element.
 
-    <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util='http://schemas.microsoft.com/wix/UtilExtension' >
-        <Product Id='PutGuidHere' Name='TestUserProduct' Language='1033' Version='0.0.0.0'>
-            <Package Id='PUT-GUID-HERE' Description='Test User Package' InstallerVersion='200' Compressed='yes' />
-                <Directory Id='TARGETDIR' Name='SourceDir'>
-                    <Component Id='TestUserProductComponent' Guid='PutGuidHere'>
-                        <util:User Id='TEST_USER1' Name='testName1' Password='pa$$$$word'/>
-                    </Component>
-            </Directory>
-    
-            <Feature Id='TestUserProductFeature' Title='Test User Product Feature' Level='1'>
-                <ComponentRef Id='TestUserProductComponent' />
-            </Feature>
-        </Product>
-    </Wix>
+```xml
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi' xmlns:util='http://schemas.microsoft.com/wix/UtilExtension' >
+    <Product Id='PutGuidHere' Name='TestUserProduct' Language='1033' Version='0.0.0.0'>
+        <Package Id='PUT-GUID-HERE' Description='Test User Package' InstallerVersion='200' Compressed='yes' />
+            <Directory Id='TARGETDIR' Name='SourceDir'>
+                <Component Id='TestUserProductComponent' Guid='PutGuidHere'>
+                    <util:User Id='TEST_USER1' Name='testName1' Password='pa$$$$word'/>
+                </Component>
+        </Directory>
 
-This is a simple example that will create a new user on the machine named &quot;testName1&quot; with the password &quot;pa$$word&quot; (the preprocessor replaces $$$$ with $$).
+        <Feature Id='TestUserProductFeature' Title='Test User Product Feature' Level='1'>
+            <ComponentRef Id='TestUserProductComponent' />
+        </Feature>
+    </Product>
+</Wix>
+```
+
+This is a simple example that will create a new user on the machine named "testName1" with the password "pa$$word" (the preprocessor replaces $$$$ with $$).
 
 To build the MSI from this WiX authoring:
 
 1. Put the above code in a file named yourfile.wxs.
-1. Replace the &quot;PUT-GUID-HERE&quot; attributes with real GUIDs.
+1. Replace the "PUT-GUID-HERE" attributes with real GUIDs.
 1. Run `candle.exe yourfile.wxs -ext %full path to WixUtilExtension.dll%`
 1. Run `light.exe yourfile.wixobj -ext %full path to WixUtilExtension.dll% -out yourfile.msi yourfile.wixout`
 

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixdirectxextension.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixdirectxextension.md
@@ -41,6 +41,7 @@ To use the WixDirectXExtension properties in an MSI, use the following steps:
 
 For example:
 
+```xml
     <PropertyRef Id="WIX_DIRECTX_PIXELSHADERVERSION" />
     
     <CustomAction Id="CA_CheckPixelShaderVersion" Error="[ProductName] requires pixel shader version 3.0 or greater." />
@@ -56,5 +57,6 @@ For example:
       <![CDATA[WIX_DIRECTX_PIXELSHADERVERSION < 300]]>
     </Custom>
     </InstallUISequence>
+```
 
 Note that the WixDirectXExtension properties are set to the value <b>NotSet</b> by default. The WixDirectXExtension custom action is configured to not fail if it encounters any errors when trying to determine DirectX capabilities. In this type of scenario, the properties will be set to their <b>NotSet</b> default values. In your setup authoring, you can compare the property values to the <b>NotSet</b> value or to a specific value to determine whether WixDirectXExtension was able to query DirectX capabilities and if so, what they are.

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixexitearlywithsuccess.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixexitearlywithsuccess.md
@@ -29,7 +29,9 @@ If you are using Votive you can add the extension using the Add Reference dialog
 
 To add a reference to the WixExitEarlyWithSuccess custom action, include the following in your WiX setup authoring:
 
+```xml
     <CustomActionRef Id="WixExitEarlyWithSuccess" />
+```
 
 This will cause WiX to add the WixExitEarlyWithSuccess custom action to your MSI, schedule it immediately after the <a href="http://msdn.microsoft.com/library/aa368600.aspx" target="_blank">FindRelatedProducts</a> action and condition it to only run if the property named NEWERVERSIONDETECTED is set.
 
@@ -37,6 +39,8 @@ This will cause WiX to add the WixExitEarlyWithSuccess custom action to your MSI
 
 In order to cause the WixExitEarlyWithSuccess to run at the desired times, you must add logic to your installer to create the NEWERVERSIONDETECTED property. To implement the major upgrade example described above, you can add an Upgrade element like the following:
 
+```xml
     <Upgrade Id="!(loc.Property_UpgradeCode)">
       <UpgradeVersion Minimum="$(var.ProductVersion)" OnlyDetect="yes" Property="NEWERVERSIONDETECTED" />
     </Upgrade>
+```

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixfailwhendeferred.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixfailwhendeferred.md
@@ -24,20 +24,22 @@ There are 3 steps you need to take to use the WixFailWhenDeferred custom action 
 
 The WiX support for WixFailWhenDeferred is included in a WiX extension library that must be added to your project prior to use. If you are using WiX on the command line you need to add the following to your light command line:
 
-    light.exe myproject.wixobj -ext WixUtilExtension
+`light.exe myproject.wixobj -ext WixUtilExtension`
 
 If you are using Votive you can add the extension using the Add Reference dialog:
 
 1. Open your Votive project in Visual Studio
 1. Right click on your project in Solution Explorer and select Add Reference...
-1. Select the <strong>WixUtilExtension.dll</strong> assembly from the list and click Add
+1. Select the **WixUtilExtension.dll** assembly from the list and click Add
 1. Close the Add Reference dialog
 
 ## Step 2: Add a reference to the WixFailWhenDeferred custom action
 
 To add a reference to the WixFailWhenDeferred custom action, include the following in your WiX setup authoring:
 
+```xml
     <CustomActionRef Id="WixFailWhenDeferred" />
+```
 
 This will cause WiX to add the WixFailWhenDeferred custom action to your MSI, schedule it immediately before the <a href="http://msdn.microsoft.com/library/aa369505.aspx" target="_blank">InstallFinalize</a> action and condition it to only run if the property WIXFAILWHENDEFERRED=1.
 

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixgamingextension.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixgamingextension.md
@@ -15,10 +15,12 @@ The [WixGamingExtension](../xsd/gaming/index.md) lets you register your applicat
 
 For an overview of Game Explorer, see <a href="http://msdn.microsoft.com/library/bb173446.aspx" target="_blank">Getting Started With Game Explorer</a>. Game Explorer relies on an embedded file (game definition file or GDF) to control the data displayed about the game. For details about GDFs, see <a href="http://msdn.microsoft.com/library/bb173445.aspx" target="_blank">The Game-Definition-File (GDF) Schema</a> and <a href="http://msdn.microsoft.com/library/bb173443.aspx" target="_blank">GDF Delivery and Localization</a>. Using WixGamingExtension, you register a game with Game Explorer using the Game element as a child of your game executable&apos;s File element:
 
+```xml
     <File Id="MyGameExeFile" Name="passenger_simulator.exe" KeyPath="yes">
         <gaming:Game Id="985D5FD3-FC40-4CE9-9EE5-F2AAAB959230">
         ...
     </File>
+```
 
 The Game/@Id attribute is used as the InstanceID attribute discussed <a href="http://msdn.microsoft.com/library/bb173446.aspx#Step_4_Call_IGameExplorer_AddGame" target="_blank">here</a>, rather than generating new GUIDs at install time, which would require persisting the generated GUID and loading it for uninstall and maintenance mode.
 
@@ -33,6 +35,7 @@ In Game Explorer, a game&apos;s context menu includes custom *tasks*:
 
 For details, see <a href="http://msdn.microsoft.com/library/bb173450.aspx" target="_blank">Game Explorer Tasks</a>. In WixGameExtension, PlayTask and SupportTask are child elements of the Game element:
 
+```xml
     <File Id="MyGameExeFile" Name="passenger_simulator.exe" KeyPath="yes">
         <gaming:Game Id="985D5FD3-FC40-4CE9-9EE5-F2AAAB959230">
             <gaming:PlayTask Name="Play" Arguments="-go" />
@@ -40,6 +43,7 @@ For details, see <a href="http://msdn.microsoft.com/library/bb173450.aspx" targe
             ...
         ...
     </File>
+```
 
 For details, see the [Gaming schema documentation](../xsd/gaming/index.md).
 
@@ -49,8 +53,10 @@ For details, see the [Gaming schema documentation](../xsd/gaming/index.md).
 
 Windows Vista includes a shell handler that lets games expose metadata in their saved-game files. For details, see <a href="http://msdn.microsoft.com/library/bb173448.aspx" target="_blank">Rich Saved Games</a>. If your game supports rich saved games, you can register it for the rich saved-game preview using the WixGamingExtension IsRichSavedGame attribute on the [Extension element](../xsd/wix/extension.md):
 
+```xml
     <ProgId Id="MyGameProgId">
         <Extension Id="MyGameSave" gaming:IsRichSavedGame="yes" />
     </ProgId>
+```
 
 <span class="signature">Implementation note: The Gaming compiler extension translates the IsRichSavedGame attribute to rows in the MSI <a href="http://msdn.microsoft.com/library/aa371168.aspx" target="_blank">Registry</a> table.</span>

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixsettingchange.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixsettingchange.md
@@ -18,7 +18,7 @@ There are two steps you need to take to use the WixBroadcastSettingChange or Wix
 
 WixBroadcastSettingChange and WixBroadcastEnvironmentChange are included in a WiX extension library that must be added to your project prior to use. If you are using WiX on the command line you need to add the following to your light command line:
 
-    light.exe myproject.wixobj -ext WixUtilExtension
+`light.exe myproject.wixobj -ext WixUtilExtension`
 
 If you are using Votive you can add the extension using the Add Reference dialog:
 
@@ -31,7 +31,9 @@ If you are using Votive you can add the extension using the Add Reference dialog
 
 To add a reference to the WixBroadcastSettingChange or WixBroadcastEnvironmentChange custom actions, include one of the following elements in your WiX setup authoring:
 
+```xml
     <CustomActionRef Id="WixBroadcastSettingChange" />
     <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+```
 
 This will cause WiX to add the custom action to your MSI and schedule it immediately after the <a href="http://msdn.microsoft.com/library/aa369505.aspx" target="_blank">InstallFinalize</a> standard action.

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixvsextension.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixvsextension.md
@@ -2015,7 +2015,9 @@ To use the WixVSExtension properties or custom actions in an MSI, use the follow
 
 For example:
 
+```xml
     <PropertyRef Id="VS2005_ROOT_FOLDER" />
     <CustomActionRef Id="VS2005Setup" />
+```
 
 When you reference any of the above properties or custom actions, the WixVSExtension automatically schedules the custom actions and pulls in properties used in the custom action conditions and execution logic.

--- a/src/Docusaurus/versioned_docs/version-v3/customactions/wixwaitforevent.md
+++ b/src/Docusaurus/versioned_docs/version-v3/customactions/wixwaitforevent.md
@@ -37,16 +37,13 @@ The WiX support for WixWaitForEvent is included in a WiX extension library that
 must be added to your project prior to use. If you are using WiX on the command
 line you need to add the following to your light command line:
 
-```
-light.exe myproject.wixobj -ext <span>WixUtilExtension</span>
-```
+`light.exe myproject.wixobj -ext WixUtilExtension`
 
 If you are using Votive you can add the extension using the Add Reference dialog:
 
 1. Open your Votive project in Visual Studio
 1. Right click on your project in Solution Explorer and select Add Reference...
-1. Select the <strong>WixUtilExtension.dll</strong> assembly from the list and click
-Add
+1. Select the **WixUtilExtension.dll** assembly from the list and click Add
 1. Close the Add Reference dialog
 
 ## Step 2: Add a reference to the WixWaitForEvent custom action
@@ -55,7 +52,9 @@ To add a reference to the WixWaitForEvent
 immediate custom action, include the following in
 your WiX setup authoring:
 
+```xml
     <CustomActionRef Id="WixWaitForEvent" />
+```
 
 This will cause WiX to add the WaitWaitForEvent custom action to your MSI 
 as an immediate custom action scheduled immediately before InstallFinalize. This 
@@ -65,7 +64,9 @@ schedule it anywhere else in your sequence.
 To add a reference to the WixWaitForEventDeferred deferred custom action, 
 include the following in your WiX setup authoring:
 
+```xml
     <CustomActionRef Id="WixWaitForEventDeferred" />
+```
 
 This deferred custom action is scheduled immediately after InstallInitialize so 
 it will block after starting script execution. You can schedule this custom 
@@ -76,7 +77,7 @@ signal either of the named automatic reset events documented above both times.
 
 ## Step 3: Build your MSI and test various scenarios
 
-Once you&apos;ve built your MSI package you can install it using msiexec.exe, Burn,
+Once you've built your MSI package you can install it using msiexec.exe, Burn,
 or by any other means you wish. When Windows Installer executes your custom action,
 Windows Installer will wait for you to signal either the event documented above.
 Depending on the named event you signal, the custom action will fail or succeed 

--- a/src/Docusaurus/versioned_docs/version-v3/wixui/dialog_reference/wixui_advanced.md
+++ b/src/Docusaurus/versioned_docs/version-v3/wixui/dialog_reference/wixui_advanced.md
@@ -14,29 +14,37 @@ To use WixUI_Advanced, you must include the following information in your setup 
 
 1. A directory with an Id named <b>APPLICATIONFOLDER</b>. This directory will be the default installation location for the product. For example:
 
-        <Directory Id="TARGETDIR" Name="SourceDir">
-          <Directory Id="ProgramFilesFolder" Name="PFiles">
-            <Directory Id="APPLICATIONFOLDER" Name="My Application Folder">
-              ...
-            </Directory>
-          </Directory>
+```xml
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder" Name="PFiles">
+        <Directory Id="APPLICATIONFOLDER" Name="My Application Folder">
+          ...
         </Directory>
+      </Directory>
+    </Directory>
+```
   
-1. A property with an Id named <b>ApplicationFolderName</b> and a value set to a string that represents the default folder name. This property is used to form the default installation location.
+2. A property with an Id named <b>ApplicationFolderName</b> and a value set to a string that represents the default folder name. This property is used to form the default installation location.
 
-    For a per-machine installation, the default installation location will be [ProgramFilesFolder][ApplicationFolderName] and the user will be able to change it in the setup UI. For a per-user installation, the default installation location will be [LocalAppDataFolder]Apps\[ApplicationFolderName] and the user will not be able to change it in the setup UI.
+For a per-machine installation, the default installation location will be [ProgramFilesFolder][ApplicationFolderName] and the user will be able to change it in the setup UI. For a per-user installation, the default installation location will be [LocalAppDataFolder]Apps\[ApplicationFolderName] and the user will not be able to change it in the setup UI.
 
-    For example:
+For example:
 
-        <Property Id="ApplicationFolderName" Value="My Application Folder" />
+```xml
+    <Property Id="ApplicationFolderName" Value="My Application Folder" />
+```
 
-1. A property with an Id named <b>WixAppFolder</b> and a value set to <b>WixPerMachineFolder</b> or <b>WixPerUserFolder</b>. This property sets the default selected value of the radio button on the install scope dialog in the setup UI where the user can choose whether to install the product per-machine or per-user. For example:
+3. A property with an Id named <b>WixAppFolder</b> and a value set to <b>WixPerMachineFolder</b> or <b>WixPerUserFolder</b>. This property sets the default selected value of the radio button on the install scope dialog in the setup UI where the user can choose whether to install the product per-machine or per-user. For example:
 
-        <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
+```xml
+    <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
+```
 
 It is possible to suppress the install scope dialog in the WixUI_Advanced dialog set so the user will not be able to choose a per-machine or per-user installation. To do this, you must set the <b>WixUISupportPerMachine</b> or <b>WixUISupportPerUser</b> WiX variables to 0. The default value for each of these variables is 1, and you should not set both of these values to 0 in the same .msi. For example, to remove the install scope dialog and support only a per-machine installation, you can set the following:
 
+```xml
     <WixVariable Id="WixUISupportPerUser" Value="0" />
+```
 
 The install scope dialog will automatically set the <a href="http://msdn.microsoft.com/library/aa367559.aspx" target="_blank">ALLUSERS</a> property for the installation session based on the user&apos;s selection. If you suppress the install scope dialog by setting either of these WiX variable values, you must manually set the ALLUSERS property to an appropriate value based on whether you want a per-machine or per-user installation.
 

--- a/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_customizations.md
+++ b/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_customizations.md
@@ -19,11 +19,13 @@ The built-in WixUI dialog sets can be customized in the following ways:
 
 WixUIExtension.dll includes a default, placeholder license agreement. To specify your product&apos;s license, override the default by specifying a WiX variable named WixUILicenseRtf with the value of an RTF file that contains your license text. You can define the variable in your WiX authoring:
 
-    <WixVariable Id="WixUILicenseRtf" Value="bobpl.rtf" />
+```xml
+<WixVariable Id="WixUILicenseRtf" Value="bobpl.rtf" />
+```
 
 Alternatively, you can define the variable using the -d switch when running <b>light</b>:
 
-    light -ext WixUIExtension -cultures:en-us -dWixUILicenseRtf=bobpl.rtf Product.wixobj -out Product.msi
+`light -ext WixUIExtension -cultures:en-us -dWixUILicenseRtf=bobpl.rtf Product.wixobj -out Product.msi`
 
 The file you specify must be in a directory <b>light</b> is looking in for files. Use the <b>-b</b> switch to add directories.
 
@@ -82,16 +84,20 @@ See [How To: Run the Installed Application After Setup](../howtos/ui_and_localiz
 
 To show optional text on the ExitDlg, set the WIXUI_EXITDIALOGOPTIONALTEXT property to the string you want to show. For example:
 
-    <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Thank you for installing this product." />
+```xml
+<Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Thank you for installing this product." />
+```
 
 The optional text has the following behavior:
 
 * The optional text is displayed as literal text, so properties surrounded by square brackets such as [ProductName] will not be resolved. If you need to include property values in the optional text, you must schedule a custom action to set the property. For example:
 
-        <CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Thank you for installing [ProductName]."/>
-        <InstallUISequence>
-          <Custom Action="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" After="FindRelatedProducts">NOT Installed</Custom>
-        </InstallUISequence>
+```xml
+<CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Thank you for installing [ProductName]."/>
+<InstallUISequence>
+    <Custom Action="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" After="FindRelatedProducts">NOT Installed</Custom>
+</InstallUISequence>
+```
 
 * Long strings will wrap across multiple lines.
 * The optional text is only shown during initial installation, not during maintenance mode or uninstall.
@@ -102,7 +108,9 @@ All text displayed in built-in WixUI dialog sets can be overridden with custom s
 
 For example, to override the descriptive text on the WelcomeDlg, you would add the following to a .wxl file in your project:
 
-    <String Id="WelcomeDlgDescription">This is a custom welcome message. Click Next to continue or Cancel to exit.</String>
+```xml
+<String Id="WelcomeDlgDescription">This is a custom welcome message. Click Next to continue or Cancel to exit.</String>
+```
 
 ## Changing the UI sequence of a built-in dialog set
 

--- a/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_dialog_library.md
+++ b/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_dialog_library.md
@@ -21,17 +21,15 @@ Assuming you have an existing installer that is functional but is just lacking a
 
 1. Add a UIRef element to your setup authoring that has an Id that matches the name of one of the dialog sets described above. For example:
 
-```
+```xml
 <Product ...>
-<UIRef Id="WixUI_InstallDir" />
+    <UIRef Id="WixUI_InstallDir" />
 </Product>
 ```
 
 2. Pass the -ext and -cultures switches to [light.exe](../overview/light.md) to reference the WixUIExtension. For example:
 
-```
-light -ext WixUIExtension -cultures:en-us Product.wixobj -out Product.msi
-```
+`light -ext WixUIExtension -cultures:en-us Product.wixobj -out Product.msi`
 
 Note - If you are using WiX in Visual Studio you can add the WixUIExtension using the Add Reference dialog and the necessary command lines will automatically be added when linking your .msi. To do this, use the following steps:
 

--- a/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_localization.md
+++ b/src/Docusaurus/versioned_docs/version-v3/wixui/wixui_localization.md
@@ -274,4 +274,6 @@ You can create a series of .msi files that each use different setup UI languages
 
 By default, WixUI will not include any translated Error or ProgressText elements. You can include them by referencing the WixUI_ErrorProgressText UI element:
 
+```xml
     <UIRef Id="WixUI_ErrorProgressText" />
+```


### PR DESCRIPTION
Another portion of documentation fixes; simple search & replace is not possible here - reviewed & fixed files in bundle/customactions/wixui directories, more to come in follow up pull requests.

- wrap code fragments in triple backticks where needed
- add missing `xml` keyword to enable syntax highlighting
- replace HTML tags with text equivalents where needed to fix issues like this:
![image](https://github.com/wixtoolset/web/assets/3204947/a56815b8-1b4d-4787-bd02-b3d0c7249d3f)
