### PR TITLE
Mention the need to specify Wix version in ext install

### DIFF
--- a/src/Docusaurus/docs/tools/wixext/index.md
+++ b/src/Docusaurus/docs/tools/wixext/index.md
@@ -47,6 +47,14 @@ wix extension add -g WixToolset.Bal.wixext
 wix build Bundle.wxs Bundle.en-us.wxl -ext WixToolset.Util.wixext -ext WixToolset.Bal.wixext
 ```
 
+:::tip
+If using an earlier Wix version (e.g. Wix 4.0.4), you have to specify it when installing the extension like so:
+
+   ```
+   wix extension add -g WixToolset.Util.wixext/4.0.4
+   ```
+:::
+
 
 ### Loading extensions in a .wixproj MSBuild project
 


### PR DESCRIPTION
The failure to specify the Wix version can result in a damaged extension which cannot run and [silently fails to install](https://github.com/wixtoolset/issues/issues/8044).