### PR TITLE
Update wixstdba_branding.md with corrected xml example

### DIFF
--- a/src/Docusaurus/versioned_docs/version-v3/bundle/authoring_bundle_package_manifest.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/authoring_bundle_package_manifest.md
@@ -47,7 +47,7 @@ Now you can add an install condition to the package so that it only installs on 
           InstallCommand="/q /ACTION=Install"
           RepairCommand="/q ACTION=Repair /hideconsole"
           UninstallCommand="/q ACTION=Uninstall /hideconsole" 
-          <strong class="highlight">InstallCondition="NOT VersionNT64 AND VersionNT >= v5.1"</strong> />
+          InstallCondition="NOT VersionNT64 AND VersionNT >= v5.1" />
     </PackageGroup>
   </Fragment>
 </Wix>

--- a/src/Docusaurus/versioned_docs/version-v3/bundle/bundle_define_searches.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/bundle_define_searches.md
@@ -59,7 +59,7 @@ After the searches are defined and stored into variables, the variables can then
         InstallCommand="/q /ACTION=Install"
         RepairCommand="/q ACTION=Repair /hideconsole"
         UninstallCommand="/q ACTION=Uninstall /hideconsole"
-        InstallCondition="x86 = 1 AND OSVersion >= v5.0.5121.0 <strong class="highlight">AND patchLevel = 0</strong>" />
+        InstallCondition="x86 = 1 AND OSVersion >= v5.0.5121.0 AND patchLevel = 0" />
     </PackageGroup>
   </Fragment>
 </Wix>

--- a/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_branding.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_branding.md
@@ -15,7 +15,7 @@ The WiX Standard Bootstrapper Application displays a generic logo in the bottom 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
       <bal:WixStandardBootstrapperApplication
         LicenseFile="path\to\license.rtf"
-        <strong class="highlight">LogoFile="path\to\customlogo.png"</strong>
+        LogoFile="path\to\customlogo.png"
         />
     </BootstrapperApplicationRef>
 
@@ -36,8 +36,9 @@ For the HyperlinkSidebarLicense UI, there are two logos and they can be configur
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkSidebarLicense">
       <bal:WixStandardBootstrapperApplication
         LicenseUrl="License.htm"
-        <strong class="highlight">LogoFile="path\to\customlogo.png" LogoSideFile="path\to\customsidelogo.png"</strong>
-        />
+        LogoFile="path\to\customlogo.png"
+        LogoSideFile="path\to\customsidelogo.png"
+    />
     </BootstrapperApplicationRef>
 
     <Chain>

--- a/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_license.md
+++ b/src/Docusaurus/versioned_docs/version-v3/bundle/wixstdba/wixstdba_license.md
@@ -15,7 +15,7 @@ When using a WixStdBA theme that displays the RTF license, it is highly recommen
   <Bundle>
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
       <bal:WixStandardBootstrapperApplication
-        <strong class="highlight">LicenseFile="path\to\license.rtf"</strong>
+        LicenseFile="path\to\license.rtf"
         LogoFile="path\to\customlogo.png"
         />
     </BootstrapperApplicationRef>
@@ -35,7 +35,7 @@ The following example links to a license page on the internet.
   <Bundle>
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
       <bal:WixStandardBootstrapperApplication
-        <strong class="highlight">LicenseUrl="http://example.com/license.html"</strong>
+        LicenseUrl="http://example.com/license.html"
         LogoFile="path\to\customlogo.png"
         />
     </BootstrapperApplicationRef>


### PR DESCRIPTION
the xml example on https://wixtoolset.org/docs/v3/bundle/wixstdba/wixstdba_branding/ is syntactically incorrect.

I also identified a few other pages with bad html formatting on top of xml examples. This PR Makes a few updates for the sanity of anyone else reading wixtoolset docs trying to grok the xml examples.

<img width="1016" alt="Screenshot 2024-04-09 at 10 57 23 AM" src="https://github.com/wixtoolset/web/assets/3855429/4ff41543-aac0-4292-8778-74a652595b94">

