### PR TITLE
Visual studio complained lots about vulnerabilities in dependencies.

### DIFF
--- a/src/FeedGenerator/FeedGenerator.csproj
+++ b/src/FeedGenerator/FeedGenerator.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="4.0.3" />
+    <PackageReference Include="Octokit" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.194" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/test/XsdToMarkDownTests/XsdToMarkdownTests.csproj
+++ b/src/test/XsdToMarkDownTests/XsdToMarkdownTests.csproj
@@ -14,13 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.20.0" />
+    <PackageReference Include="Markdig" Version="0.37.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" PrivateAssets="All" />
-    <PackageReference Include="xunit" Version="2.4.1" PrivateAssets="All" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" PrivateAssets="All" />
+    <PackageReference Include="xunit" Version="2.9.0" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bump them all to fix.
WindowsAzure.Storage is listed as deprecated, haven't resolved that in this PR.  It looks like more work to migrate.